### PR TITLE
bugfix: copy is corrupting binary files

### DIFF
--- a/gruntconfig/copy.js
+++ b/gruntconfig/copy.js
@@ -23,6 +23,7 @@ var copy = {
     filter: 'isFile',
     options: {
       mode: true,
+      noProcess: ['**/*.{gif,ico,jpg,png,tif,pdf,mp4,kmz,gz,zip}'],
       process: function (content/*, srcpath*/) {
         // replace {{VERSION}} in php/html with version from package.json
         return content.replace('{{VERSION}}', packageJson.version);


### PR DESCRIPTION
There might be a better fix because this only targets files that match the specific extensions in the list, but this patch solves my current issue where images are being corrupted. I added many of the most common types, but there are too many to list everything.